### PR TITLE
Update office_js_api_branch and base_version to v9.4.1 in configurati…

### DIFF
--- a/builder_tests_config.json
+++ b/builder_tests_config.json
@@ -3,7 +3,7 @@
   "chat_id_file": "builder_chat",
   "dep_test_branch": "",
   "build_tools_branch": "",
-  "office_js_api_branch": "release/v9.4.0",
+  "office_js_api_branch": "hotfix/v9.4.1",
   "document_builder_samples": "",
   "password": "",
   "hosts_arm64": [

--- a/scheduler_config.json
+++ b/scheduler_config.json
@@ -5,7 +5,7 @@
     "builder_run_cmd": "uv run inv builder-test -h -p 3 --version {version} --connect-portal --telegram",
     "desktop_run_cmd": "uv run inv desktop-test -d -h -p 5 --version {version} --telegram --open-retries 1 --connect-portal",
     "core_run_cmd": "uv run inv conversion-test --telegram -q --version {version}",
-    "base_version": "9.4.0",
+    "base_version": "9.4.1",
     "max_builds": 50,
     "recheck_count": 2,
     "recheck_all": false,


### PR DESCRIPTION
…on files

- Changed the `office_js_api_branch` in `builder_tests_config.json` from `release/v9.4.0` to `hotfix/v9.4.1`.
- Updated the `base_version` in `scheduler_config.json` from `9.4.0` to `9.4.1` to reflect the latest version changes.